### PR TITLE
Re-work Gurobi initialization.

### DIFF
--- a/available_interfaces/gurobi/src/Gurobi.hpp
+++ b/available_interfaces/gurobi/src/Gurobi.hpp
@@ -19,6 +19,7 @@ private:
     int _verbosity, optimstatus;
     bool has_been_added;
     void add_in_constraint(LinearConstraint *con, double coef=0);
+    void add_variables_from(LinearConstraint *con, double coef=0);
 
 public:
 


### PR DESCRIPTION
Add all variables at the beginning and then perform only single model->update().
Greatly helps to speed up initialization of large problems with sparse constraints.
