### PR TITLE
domain_type bug fixed

### DIFF
--- a/Numberjack/solvers/Mistral2/mistral/src/include/mistral_variable.hpp
+++ b/Numberjack/solvers/Mistral2/mistral/src/include/mistral_variable.hpp
@@ -1560,7 +1560,7 @@ namespace Mistral {
   public:
 
     union {
-      int domain_type;
+      unsigned int domain_type;
       int* bool_domain;
     };
     union {


### PR DESCRIPTION
This fixes a bug I had few months before. If domain_type is not unassigned, Mistral can give wrong results (I had two examples). 