### PR TITLE
Fix compatibility with python3

### DIFF
--- a/Numberjack/Decomp.py
+++ b/Numberjack/Decomp.py
@@ -537,16 +537,16 @@ def decompose_BinPredicate(self):
     arity = get_arity(self)
     scope = get_scope(self)
     res = Variable(self.get_lb(),self.get_ub())
-    if arity is 0:
+    if arity == 0:
         val = evaluate(self, dict([]))
         res2 = Variable(val,val,str(val))
         return [res2]
-    elif arity is 1:
+    elif arity == 1:
         return [res, Table([res, scope[0]], [(evaluate(self, dict([(scope[0],val0)])), val0) for val0 in (scope[0].domain_ if scope[0].domain_ is not None else range(scope[0].get_lb(), scope[0].get_ub()+1))])]
-    elif arity is 2:
+    elif arity == 2:
         product = cartesian_product(self)  # check if decomposition is feasible in size
         return [res, Table([res, scope[0], scope[1]], [(evaluate(self, dict([(scope[0],val0), (scope[1],val1)])), val0, val1) for val0 in (scope[0].domain_ if scope[0].domain_ is not None else range(scope[0].get_lb(), scope[0].get_ub()+1)) for val1 in (scope[1].domain_ if scope[1].domain_ is not None else range(scope[1].get_lb(), scope[1].get_ub()+1))])]
-    elif arity is 3:
+    elif arity == 3:
         product = cartesian_product(self)  # check if decomposition is feasible in size
         return [res, Table([res, scope[0], scope[1], scope[2]], [(evaluate(self, dict([(scope[0],val0), (scope[1],val1), (scope[2],val2)])), val0, val1, val2) for val0 in (scope[0].domain_ if scope[0].domain_ is not None else range(scope[0].get_lb(), scope[0].get_ub()+1)) for val1 in (scope[1].domain_ if scope[1].domain_ is not None else range(scope[1].get_lb(), scope[1].get_ub()+1)) for val2 in (scope[2].domain_ if scope[2].domain_ is not None else range(scope[2].get_lb(), scope[2].get_ub()+1))])]
 #    elif arity is 4:
@@ -573,18 +573,18 @@ def decompose_Minimise(self):
         res = []
         for i in range(len(self.children[0].children)):
             res.extend(decompose_Minimise(Minimise(Mul([self.children[0].children[i], self.children[0].parameters[0][i]]))))
-        return res + [decompose_Minimise(Minimise(e)) for e in self.children[0].parameters[1:] if e is not 0]
+        return res + [decompose_Minimise(Minimise(e)) for e in self.children[0].parameters[1:] if e != 0]
     else:
         product = cartesian_product(self.children[0])  # check if decomposition is feasible in size
         arity = get_arity(self.children[0])
         scope = get_scope(self.children[0])
         #print "decompose ", self.children[0], " size: ", product, " arity: ", arity, " scope: ", scope
-        if arity is 0:
+        if arity == 0:
             return [PostNullary(evaluate(self.children[0], dict([])))]
-        elif arity is 1:
+        elif arity == 1:
             costs = [evaluate(self.children[0], dict([(scope[0],val0)])) for val0 in (scope[0].domain_ if scope[0].domain_ is not None else range(scope[0].get_lb(), scope[0].get_ub()+1))]
             return [PostUnary(scope[0], costs)]
-        elif arity is 2:
+        elif arity == 2:
             costs = [evaluate(self.children[0], dict([(scope[0],val0), (scope[1],val1)])) for val0 in (scope[0].domain_ if scope[0].domain_ is not None else range(scope[0].get_lb(), scope[0].get_ub()+1)) for val1 in (scope[1].domain_ if scope[1].domain_ is not None else range(scope[1].get_lb(), scope[1].get_ub()+1))]
             return [PostBinary(scope[0], scope[1], costs)]
         else:

--- a/Numberjack/XCSPOut.py
+++ b/Numberjack/XCSPOut.py
@@ -332,7 +332,7 @@ class XCSPOutput():
         """
         This adds a global constraint to the list of constraints
         """
-        if self.global_map.get(expr.get_operator()) is "NOT_SUPPORTED":
+        if self.global_map.get(expr.get_operator()) == "NOT_SUPPORTED":
             print("Global operator, %s, is not supported, yet" % expr.get_operator())
         else:
             conformat = self.global_format.get(expr.get_operator())
@@ -342,7 +342,7 @@ class XCSPOutput():
 
             # Create intermediate variable for storing result of Element
             index = None
-            if expr.get_operator() is "Element":
+            if expr.get_operator() == "Element":
                 index = self.create_variable(1, len(expr.get_children())-1,
                                              Name="Result of Element C%d" %
                                                 self.__local_con_idx)
@@ -383,7 +383,7 @@ class XCSPOutput():
                     con_string += "\t\t\tV%d\n" % val.ident
 
             if "VARS" in conformat:
-                if expr.get_operator() is "Element":
+                if expr.get_operator() == "Element":
                     con_string += "V%d\n\t\t\t" % index
                     del(params[-1])
                 con_string += "["
@@ -409,7 +409,7 @@ class XCSPOutput():
                     duration = task.duration
                     end      = task.get_ub()
                     height   = task#.something
-                    con_string += "{ O%d D%d E%d H%d}" (origin,duration,end,height)
+                    con_string += "{ O%d D%d E%d H%d}"%(origin,duration,end,height)
                 con_string += " ]\n"
 
             if "MATRIX" in conformat:
@@ -583,9 +583,9 @@ class XCSPOutput():
         semantics = expr.parameters[1]
         scope = expr.get_children()
 
-        if semantics is "conflict":
+        if semantics == "conflict":
             semantics = "conflicts"
-        elif semantics is "support":
+        elif semantics == "support":
             semantics = "supports"
 
         relation  = "\t<relation name=\"R%d\"" % self.__local_rel_idx

--- a/Numberjack/__init__.py
+++ b/Numberjack/__init__.py
@@ -733,7 +733,7 @@ class Model(object):
         #SDG: check if it is an optimization problem
         if not any([issubclass(type(expr), Minimise) or issubclass(type(expr), Maximise) or issubclass(type(expr), CostFunction) for expr in self.__expressions]):
             self.upper_bound = 1
-        if solver is not None and solver.Library is 'Toulbar2' and self.upper_bound is not None:
+        if solver != None and solver.Library == 'Toulbar2' and self.upper_bound != None:
             solver.setOption('updateUb', str(self.upper_bound))
 
         if self.closed == len(self.__expressions):
@@ -2125,7 +2125,7 @@ class Sum(Predicate):
                 return X[0]
             else:
                 return Add([X[0], addition(X[1:])])   #SDG: use specific Add BinPredicate instead of Sum
-        return [addition([(child if coef is 1 else (child * Variable(coef,coef,str(coef)))) for child, coef in zip(self.children, self.parameters[0])] + [Variable(e,e,str(e)) for e in self.parameters[1:] if e is not 0])]
+        return [addition([(child if coef==1 else (child * Variable(coef,coef,str(coef)))) for child, coef in zip(self.children, self.parameters[0])] + [Variable(e,e,str(e)) for e in self.parameters[1:] if e != 0])]
 
 
 class OrderedSum(Predicate):
@@ -3028,7 +3028,7 @@ def load_in_decompositions():
     # First add the constraints
     for attr_name in dir(Decomp):
         attr = getattr(Decomp, attr_name)
-        if hasattr(attr, "__name__") and attr.__name__.find("decompose") is -1:
+        if hasattr(attr, "__name__") and attr.__name__.find("decompose")==-1:
             if not hasattr(sys.modules[__name__], attr.__name__):
                 setattr(sys.modules[__name__], attr.__name__, attr)
 

--- a/setup.py
+++ b/setup.py
@@ -43,13 +43,13 @@ disabled_extensions = []  # The names of solver interfaces which have been
 
 if sys.platform == 'darwin':
     EXTRA_COMPILE_ARGS.extend([
-        '-stdlib=libstdc++', '-Wno-shorten-64-to-32',
+        '-stdlib=libc++', '-Wno-shorten-64-to-32',
         '-arch', 'x86_64',  # force 64bit only builds on Mac
 
         # ignore warning about swig code
         '-Wno-self-assign', '-Wno-unused-const-variable',
     ])
-    EXTRA_LINK_ARGS.extend(['-arch', 'x86_64', '-stdlib=libstdc++'])
+    EXTRA_LINK_ARGS.extend(['-arch', 'x86_64', '-stdlib=libc++'])
 elif sys.platform.startswith('linux'):
     EXTRA_COMPILE_ARGS.extend([
         '-Wno-narrowing',
@@ -88,10 +88,10 @@ class njbuild_ext(_build_ext):
             _build_ext.build_extension(self, ext)
 
             # Record the names of extensions which were successful, trim '_'
-            self.builtsolvernames.append(ext.name[1:])
+            self.builtsolvernames.append(ext.name.split('.')[-1][1:])
 
         except CCompilerError:
-            self.failedsolvernames.append(ext.name[1:])
+            self.failedsolvernames.append(ext.name.split('.')[-1][1:])
 
 
 # ------------------------------ Helper Methods ------------------------------
@@ -178,7 +178,7 @@ def listextfiles(folder, extension=".cpp"):
 
 mistralsrc = 'Numberjack/solvers/Mistral/mistral/lib/src'
 mistral = Extension(
-    '_Mistral',
+    'Numberjack.solvers._Mistral',
     sources=[
         'Numberjack/solvers/Mistral.i',
         'Numberjack/solvers/Mistral/Mistral.cpp',
@@ -205,7 +205,7 @@ extensions.append(mistral)
 
 mistral2src = 'Numberjack/solvers/Mistral2/mistral/src/lib'
 mistral2 = Extension(
-    '_Mistral2',
+    'Numberjack.solvers._Mistral2',
     sources=[
         'Numberjack/solvers/Mistral2.i',
         'Numberjack/solvers/Mistral2/Mistral2.cpp',
@@ -234,7 +234,7 @@ extensions.append(mistral2)
 toulbar2src = 'Numberjack/solvers/Toulbar2/lib/src'
 toulbar2incopsrc = 'Numberjack/solvers/Toulbar2/lib/src/incop'
 toulbar2 = Extension(
-    '_Toulbar2',
+    'Numberjack.solvers._Toulbar2',
     sources=[
         'Numberjack/solvers/Toulbar2.i',
         'Numberjack/solvers/Toulbar2/Toulbar2.cpp',
@@ -269,7 +269,7 @@ extensions.append(toulbar2)
 
 
 mip = Extension(
-    '_MipWrapper',
+    'Numberjack.solvers._MipWrapper',
     sources=[
         'Numberjack/solvers/MipWrapper.i',
         'Numberjack/solvers/MipWrapper/MipWrapper.cpp',
@@ -287,7 +287,7 @@ extensions.append(mip)
 
 
 sat = Extension(
-    '_SatWrapper',
+    'Numberjack.solvers._SatWrapper',
     sources=[
         'Numberjack/solvers/SatWrapper.i',
         'Numberjack/solvers/SatWrapper/SatWrapper.cpp',
@@ -311,7 +311,7 @@ extensions.append(sat)
 
 
 minisat = Extension(
-    '_MiniSat',
+    'Numberjack.solvers._MiniSat',
     sources=[
         'Numberjack/solvers/MiniSat.i',
         'Numberjack/solvers/MiniSat/MiniSat.cpp',
@@ -340,7 +340,7 @@ extensions.append(minisat)
 
 
 walksat = Extension(
-    '_Walksat',
+    'Numberjack.solvers._Walksat',
     sources=[
         'Numberjack/solvers/Walksat.i',
         'Numberjack/solvers/Walksat/Walksat.cpp',
@@ -399,7 +399,7 @@ if cplexhome:
         return [getlibdirs(cplexlibfolder), getlibdirs(concertlibfolder)]
 
     cplex = Extension(
-        '_CPLEX',
+        'Numberjack.solvers._CPLEX',
         sources=[
             'Numberjack/solvers/CPLEX.i',
             'Numberjack/solvers/CPLEX/CPLEX.cpp',
@@ -449,7 +449,7 @@ if gurobihome:
         return ['gurobi_c++', get_gurobi_libname()]
 
     gurobi = Extension(
-        '_Gurobi',
+        'Numberjack.solvers._Gurobi',
         sources=[
             'Numberjack/solvers/Gurobi.i',
             'Numberjack/solvers/Gurobi/Gurobi.cpp',
@@ -522,7 +522,7 @@ if scipopthome:
     scipincfolder = os.path.join(scipfolder, "src")
 
     scip = Extension(
-        '_SCIP',
+        'Numberjack.solvers._SCIP',
         sources=[
             'Numberjack/solvers/SCIP.i',
             'Numberjack/solvers/SCIP/SCIP.cpp',
@@ -554,7 +554,7 @@ else:
 # Possibly compile only a subset of the solvers. This can be specified as a CSV
 # list on the command line or by passing -solver multiple times, e.g:
 # python setup.py build -solver Mistral,Mistral2 -solver SCIP
-allsolvers = dict((e.name[1:], e) for e in extensions)
+allsolvers = dict((e.name.split('.')[-1][1:], e) for e in extensions)
 SOLVERARG = "-solver"
 solversubsetnames = set()
 while SOLVERARG in sys.argv:


### PR DESCRIPTION
I could not install the module under python3.8 and patched the code so as to be able to do it. The changes are minor and allow Numberjack to be installed with these python versions. Tested on Mac OS and linux